### PR TITLE
Sync/Async OnWorkerTerminate

### DIFF
--- a/demo/PoolDemo.lpi
+++ b/demo/PoolDemo.lpi
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="11"/>
+    <Version Value="12"/>
     <PathDelim Value="\"/>
     <General>
+      <Flags>
+        <CompatibilityMode Value="True"/>
+      </Flags>
       <SessionStorage Value="InProjectDir"/>
-      <MainUnit Value="0"/>
       <Title Value="PoolDemo"/>
       <Scaled Value="True"/>
       <ResourceType Value="res"/>
@@ -24,7 +26,6 @@
     </PublishOptions>
     <RunParams>
       <FormatVersion Value="2"/>
-      <Modes Count="0"/>
     </RunParams>
     <RequiredPackages Count="2">
       <Item1>
@@ -102,6 +103,7 @@
     </SearchPaths>
     <Linking>
       <Debugging>
+        <DebugInfoType Value="dsDwarf2Set"/>
         <UseHeaptrc Value="True"/>
       </Debugging>
       <Options>

--- a/demo/mainform.lfm
+++ b/demo/mainform.lfm
@@ -1,14 +1,14 @@
 object Form1: TForm1
   Left = 837
-  Height = 340
+  Height = 482
   Top = 385
   Width = 523
   Caption = 'High Performance Thread Pool Demo'
-  ClientHeight = 340
+  ClientHeight = 482
   ClientWidth = 523
   OnCreate = FormCreate
   OnDestroy = FormDestroy
-  LCLVersion = '2.0.10.0'
+  LCLVersion = '2.2.0.4'
   object Button1: TButton
     Left = 395
     Height = 25
@@ -71,6 +71,14 @@ object Form1: TForm1
     Caption = 'Wait Any'
     OnClick = Button5Click
     TabOrder = 5
+  end
+  object Memo2: TMemo
+    Left = 8
+    Height = 90
+    Top = 344
+    Width = 374
+    ScrollBars = ssVertical
+    TabOrder = 6
   end
   object Timer1: TTimer
     Enabled = False

--- a/src/hpworkengine.pp
+++ b/src/hpworkengine.pp
@@ -23,6 +23,7 @@ uses
   HPWork;
 
 type
+
   THPWork = HPWork.THPWork;
 
   { THPWorkEngine }


### PR DESCRIPTION
New implementation to dispatch a callback when a worker thread is terminated.

Sync mode: Uses the OnTerminate of the TThread class, by default it handles the callback using synchronize
Async mode: Calls the .Terminate on the thread context, beware, that can cause an AV if manipulating GUI components

A new property class of ThreadClass was implemented at the THPThreadPool, so you can inject your own class if some sort of customization is necessary

    property OnTerminateWorker: TNotifyEvent read FNotify write SetNotify;
    property UseSyncTerminate: Boolean read FSyncTerminate write SetSyncTerminate;
    property ThreadClass: THPThreadClass read FThreadClass write SetThreadClass;
